### PR TITLE
Define non-anonymous module.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -12,7 +12,7 @@
     factory(root, exports, require('underscore'));
   } else if (typeof define === 'function' && define.amd) {
     // AMD
-    define(['underscore', 'jquery', 'exports'], function(_, $, exports) {
+    define('backbone', ['underscore', 'jquery', 'exports'], function(_, $, exports) {
       // Export global even in AMD case in case this script is loaded with
       // others that may still expect a global Backbone.
       root.Backbone = factory(root, exports, _, $);


### PR DESCRIPTION
amdjs/underscore is non-anonymous.

jquery is non-anonymous.

I see no reason why this should fuck build tools.
