### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2013 Jeremy Ashkenas, DocumentCloud
+Copyright (c) 2010-2014 Jeremy Ashkenas, DocumentCloud
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation


### PR DESCRIPTION
The copyright year was out of date. Copyright notices should reflect the current year. So that ongoing work is explicitly covered by the license. This commit updates the listed year to 2014.
see: http://www.copyright.gov/circs/circ01.pdf for more info
